### PR TITLE
feat: add eval:true to fix layout

### DIFF
--- a/pre-course.qmd
+++ b/pre-course.qmd
@@ -7,6 +7,7 @@ the r-cubed courses (for instance, introductory and intermediate).
 
 ```{r}
 #| echo: false
+#| eval: true 
 #| output: asis
 cat(r3admin::read_common("reading-website.md"))
 ```
@@ -15,6 +16,7 @@ cat(r3admin::read_common("reading-website.md"))
 
 ```{r}
 #| echo: false
+#| eval: true 
 #| output: asis
 cat(r3admin::read_common("installing-programs.md"))
 ```


### PR DESCRIPTION
In my browser (Google Chrome Version 124.0.6367.92), the layout of the code chunks are not as expected (i.e., no list layout and the panel-tab not shown correctly): 
![Screenshot 2024-05-01 at 15 29 44](https://github.com/rostools/guides/assets/40836345/cf24bf6d-22b3-4c93-91e8-bcf6a3e619ab)

They look nice on the intermediate course website. The only difference, I could see, was "eval: true", so I added that :)